### PR TITLE
Add support for Relation changes in Laravel 5.4 

### DIFF
--- a/src/Relations/BelongsToThrough.php
+++ b/src/Relations/BelongsToThrough.php
@@ -191,7 +191,11 @@ class BelongsToThrough extends Relation
             $one = $model->getQualifiedKeyName();
         }
 
-        $key = $this->wrap($this->getQualifiedParentKeyName());
+        $key = $this->parent
+            ->newQueryWithoutScopes()
+            ->getQuery()
+            ->getGrammar()
+            ->wrap($this->getQualifiedParentKeyName());
 
         $query->where(new Expression($alias.'.'.$this->getParent()->getKeyName()), '=', new Expression($key));
     }
@@ -205,7 +209,7 @@ class BelongsToThrough extends Relation
      *
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function getRelationQuery(Builder $query, Builder $parent, $columns = ['*'])
+    public function getRelationExistenceQuery(Builder $query, Builder $parent, $columns = ['*'])
     {
         $query->select($columns);
 


### PR DESCRIPTION
Rename getRelationQuery to getRelationExistenceQuery for Laravel 5.4 compatibility. Removed usage of moved wrap() method.