### PR TITLE
Fixed Issue # 23

### DIFF
--- a/src/Traits/BelongsToThrough.php
+++ b/src/Traits/BelongsToThrough.php
@@ -12,14 +12,15 @@ trait BelongsToThrough
      *
      * @param string       $related
      * @param string|array $through
-     * @param string|null  $localKey Primary Key (Default: id)
-     * @param string       $prefix   Foreign key prefix
+     * @param string|null  $localKey         Primary Key (Default: id)
+     * @param string       $prefix           Foreign key prefix
+     * @param array        $foreignKeyLookup Foreign keys for models
      *
      * @throws \Exception
      *
      * @return \Znck\Eloquent\Relations\BelongsToThrough
      */
-    public function belongsToThrough($related, $through, $localKey = null, $prefix = '')
+    public function belongsToThrough($related, $through, $localKey = null, $prefix = '', $foreignKeyLookup = [])
     {
         if (! $this instanceof Model) {
             throw new Exception('belongsToThrough can used on '.Model::class.' only.');
@@ -55,6 +56,18 @@ trait BelongsToThrough
         }
 
         $models[] = $this;
+
+        foreach ($foreignKeyLookup as $model => $foreignKey) {
+            $object = new $model();
+
+            if (! $object instanceof Model) {
+                throw new InvalidArgumentException('Through model should be instance of '.Model::class.'.');
+            }
+
+            if ($foreignKey) {
+                $foreignKeys[$object->getTable()] = $foreignKey;
+            }
+        }
 
         return new Relation($relatedModel->newQuery(), $this, $models, $localKey, $prefix, $foreignKeys);
     }


### PR DESCRIPTION
https://github.com/znck/belongs-to-through/issues/23

For the next situation:

```

preguntas:
  cod_preg: unsigned int, primary

eval_rel_preg:
  cod_erp : unsigned int, primary
  id_preg: unsigned int, foreign(preguntas)

eval_respuesta_estudiante:
  cod_ere: unsigned int, primary
  id_erp : unsigned int, foreign(eval_rel_preg)

```

We can relate the model EvaluacionRespuestaEstudiante (eval_respuesta_estudiante) to Pregunta (preguntas) through EvaluacionPregunta (eval_rel_preg).

```

public function pregunta()
    {
        public function pregunta()
        {
            return $this->belongsToThrough(
                Pregunta::class, [[EvaluacionPregunta::class, 'id_erp']], null, '', [Pregunta::class => 'id_preg']
            );
        }
    }
```